### PR TITLE
Add donations and payment profiles tracking

### DIFF
--- a/servers/Package.resolved
+++ b/servers/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8805d3e0dd2a19dacb8f3aabfba1a1873ea2b787fc5f2de9db78181e1210cc20",
+  "originHash" : "18e66fb0f441d627abf0888574095fd4919f5f8eba91fb8a876940f61f86b8b7",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit.git",
       "state" : {
-        "revision" : "b5f82fb9dc238f2fcac53d721a222513a152613c",
-        "version" : "5.3.0"
+        "revision" : "2033b3e661238dda3d30e36a2d40987499d987de",
+        "version" : "5.2.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
-        "version" : "4.2.0"
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
       }
     },
     {

--- a/servers/Package.swift
+++ b/servers/Package.swift
@@ -19,6 +19,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.65.0"),
         // Vapor JWT
         .package(url: "https://github.com/vapor/jwt.git", from: "5.0.0"),
+        // Crypto for hashing
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.3.0"),
 
         // OpenAPI/Swagger generation
         .package(url: "https://github.com/dankinsoid/VaporToOpenAPI.git", from: "4.9.1")
@@ -34,6 +36,7 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOPosix", package: "swift-nio"),
                 .product(name: "JWT", package: "jwt"),
+                .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "VaporToOpenAPI", package: "VaporToOpenAPI")
             ],
             swiftSettings: swiftSettings

--- a/servers/Sources/MembersServer/Controllers/ApiKeysController.swift
+++ b/servers/Sources/MembersServer/Controllers/ApiKeysController.swift
@@ -1,0 +1,87 @@
+import Vapor
+import VaporToOpenAPI
+
+struct ApiKeysController: RouteCollection {
+    private static let apiKeyIdParam = "id"
+
+    func boot(routes: any RoutesBuilder) throws {
+        let jwtProtected = routes.grouped(UserAuthenticator(), User.guardMiddleware())
+        let openApiProtected = jwtProtected.groupedOpenAPI(auth: .bearer())
+
+        openApiProtected.get("users", ":userID", "api-keys", use: self.getUserApiKeys)
+            .openAPI(
+                summary: "Get user's API keys",
+                description: "Get all API keys for a specific user (admin only)",
+                response: .type([ApiKeyResponseDTO].self)
+            )
+
+        openApiProtected.post("users", ":userID", "api-keys", use: self.createApiKey)
+            .openAPI(
+                summary: "Create API key",
+                description: "Create a new API key for a user (admin only)",
+                body: .type(ApiKeyRequestDTO.self),
+                response: .type(ApiKeyResponseDTO.self)
+            )
+
+        let apiKeys = openApiProtected.grouped("api-keys")
+
+        apiKeys.delete(":\(Self.apiKeyIdParam)", use: self.deleteApiKey)
+            .openAPI(
+                summary: "Delete API key",
+                description: "Delete an API key by id (admin only)",
+                statusCode: .noContent
+            )
+    }
+
+    @Sendable
+    func getUserApiKeys(req: Request) async throws -> [ApiKeyResponseDTO] {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+
+        guard let userId = req.parameters.get("userID", as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing user ID parameter.")
+        }
+
+        return try await req.apiKeyService.getApiKeys(for: userId)
+    }
+
+    @Sendable
+    func createApiKey(req: Request) async throws -> ApiKeyResponseDTO {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+        let id = try curUser.requireID()
+
+        try ApiKeyRequestDTO.validate(content: req)
+        let dto = try req.content.decode(ApiKeyRequestDTO.self)
+
+        guard let userId = req.parameters.get("userID", as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing user ID parameter.")
+        }
+
+        return try await req.apiKeyService.createApiKey(
+            asUser: id,
+            for: userId,
+            from: dto
+        )
+    }
+
+    @Sendable
+    func deleteApiKey(req: Request) async throws -> HTTPStatus {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+        let id = try curUser.requireID()
+
+        guard let apiKeyId = req.parameters.get(Self.apiKeyIdParam, as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing API key ID parameter.")
+        }
+
+        try await req.apiKeyService.deleteApiKey(asUser: id, id: apiKeyId)
+        return .noContent
+    }
+}

--- a/servers/Sources/MembersServer/Controllers/DonationsController.swift
+++ b/servers/Sources/MembersServer/Controllers/DonationsController.swift
@@ -1,0 +1,151 @@
+import Vapor
+import VaporToOpenAPI
+
+struct DonationsController: RouteCollection {
+    private static let donationIdParam = "id"
+    private static let userIdParam = "userID"
+
+    func boot(routes: any RoutesBuilder) throws {
+        let jwtProtected = routes.grouped(UserAuthenticator(), User.guardMiddleware())
+        let openApiProtected = jwtProtected.groupedOpenAPI(auth: .bearer())
+
+        let donations = openApiProtected.grouped("donations")
+
+        donations.get(use: self.getAllDonations)
+            .openAPI(
+                summary: "Get all donations",
+                description: "Get a list of all donations (admin only)",
+                response: .type([DonationResponseDTO].self)
+            )
+
+        donations.get(":\(Self.donationIdParam)", use: self.getDonation)
+            .openAPI(
+                summary: "Get a donation by id",
+                description: "Get a specific donation by id (admin only)",
+                response: .type(DonationResponseDTO.self)
+            )
+
+        donations.post(use: self.addDonation)
+            .openAPI(
+                summary: "Add a donation",
+                description: "Add a new donation (admin only)",
+                body: .type(DonationRequestDTO.self),
+                response: .type(DonationResponseDTO.self)
+            )
+
+        donations.put(":\(Self.donationIdParam)", use: self.updateDonation)
+            .openAPI(
+                summary: "Update a donation",
+                description: "Update an existing donation (admin only)",
+                body: .type(DonationRequestDTO.self),
+                response: .type(DonationResponseDTO.self)
+            )
+
+        donations.delete(":\(Self.donationIdParam)", use: self.deleteDonation)
+            .openAPI(
+                summary: "Delete a donation",
+                description: "Delete a donation by id (admin only)",
+                statusCode: .noContent
+            )
+
+        openApiProtected.get("users", ":\(Self.userIdParam)", "donations", use: self.getUserDonations)
+            .openAPI(
+                summary: "Get user's donations",
+                description: "Get all donations for a specific user",
+                response: .type([DonationResponseDTO].self)
+            )
+    }
+
+    @Sendable
+    func getAllDonations(req: Request) async throws -> [DonationResponseDTO] {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+
+        return try await req.donationService.getAllDonations()
+    }
+
+    @Sendable
+    func getDonation(req: Request) async throws -> DonationResponseDTO {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+
+        guard let donationId = req.parameters.get(Self.donationIdParam, as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing donation ID parameter.")
+        }
+
+        let donation = try await req.donationService.getDonation(for: donationId)
+        guard let donation else {
+            throw DonationError.donationNotFound
+        }
+
+        return donation
+    }
+
+    @Sendable
+    func addDonation(req: Request) async throws -> DonationResponseDTO {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+        let id = try curUser.requireID()
+
+        try DonationRequestDTO.validate(content: req)
+        let dto = try req.content.decode(DonationRequestDTO.self)
+
+        return try await req.donationService.addDonation(asUser: id, from: dto)
+    }
+
+    @Sendable
+    func updateDonation(req: Request) async throws -> DonationResponseDTO {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+        let id = try curUser.requireID()
+
+        try DonationRequestDTO.validate(content: req)
+
+        let dto = try req.content.decode(DonationRequestDTO.self)
+        guard let donationId = req.parameters.get(Self.donationIdParam, as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing donation ID parameter.")
+        }
+
+        return try await req.donationService.updateDonation(asUser: id, from: dto, for: donationId)
+    }
+
+    @Sendable
+    func deleteDonation(req: Request) async throws -> HTTPStatus {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+        let id = try curUser.requireID()
+
+        guard let donationId = req.parameters.get(Self.donationIdParam, as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing donation ID parameter.")
+        }
+
+        try await req.donationService.deleteDonation(asUser: id, id: donationId)
+        return .noContent
+    }
+
+    @Sendable
+    func getUserDonations(req: Request) async throws -> [DonationResponseDTO] {
+        let curUser = try req.auth.require(User.self)
+        let id = try curUser.requireID()
+
+        guard let userId = req.parameters.get("userID", as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing user ID parameter.")
+        }
+
+        guard curUser.isAdmin || userId == id else {
+            throw UserError.userNotAdmin
+        }
+
+        return try await req.donationService.getDonations(for: userId)
+    }
+}

--- a/servers/Sources/MembersServer/Controllers/ExternalDonationsController.swift
+++ b/servers/Sources/MembersServer/Controllers/ExternalDonationsController.swift
@@ -1,0 +1,33 @@
+import Vapor
+import VaporToOpenAPI
+
+struct ExternalDonationsController: RouteCollection {
+    func boot(routes: any RoutesBuilder) throws {
+        let donations = routes.grouped("donations")
+
+        donations.post(use: self.createDonation)
+            .openAPI(
+                summary: "Create donation via API key",
+                description: "Create a new donation using an API key in X-API-Key header",
+                body: .type(DonationRequestDTO.self),
+                response: .type(DonationResponseDTO.self)
+            )
+    }
+
+    @Sendable
+    func createDonation(req: Request) async throws -> DonationResponseDTO {
+        guard let apiKeyHeader = req.headers["X-API-Key"].first else {
+            throw Abort(.unauthorized, reason: "API key required")
+        }
+
+        let apiKey = try await req.donationService.verifyApiKey(apiKeyHeader)
+
+        try DonationRequestDTO.validate(content: req)
+        let dto = try req.content.decode(DonationRequestDTO.self)
+
+        return try await req.donationService.addDonationWithApiKey(
+            apiKey: apiKey,
+            from: dto
+        )
+    }
+}

--- a/servers/Sources/MembersServer/Controllers/PaymentProfilesController.swift
+++ b/servers/Sources/MembersServer/Controllers/PaymentProfilesController.swift
@@ -1,0 +1,112 @@
+import Vapor
+import VaporToOpenAPI
+
+struct PaymentProfilesController: RouteCollection {
+    private static let profileIdParam = "id"
+    private static let userIdParam = "userID"
+
+    func boot(routes: any RoutesBuilder) throws {
+        let jwtProtected = routes.grouped(UserAuthenticator(), User.guardMiddleware())
+        let openApiProtected = jwtProtected.groupedOpenAPI(auth: .bearer())
+
+        openApiProtected.get("users", ":\(Self.userIdParam)", "payment-profiles", use: self.getUserPaymentProfiles)
+            .openAPI(
+                summary: "Get user's payment profiles",
+                description: "Get all payment profiles for a specific user",
+                response: .type([PaymentProfileResponseDTO].self)
+            )
+
+        let profiles = openApiProtected.grouped("payment-profiles")
+
+        profiles.get(":\(Self.profileIdParam)", use: self.getPaymentProfile)
+            .openAPI(
+                summary: "Get a payment profile by id",
+                description: "Get a specific payment profile by id (admin only)",
+                response: .type(PaymentProfileResponseDTO.self)
+            )
+
+        profiles.post(use: self.addPaymentProfile)
+            .openAPI(
+                summary: "Add a payment profile",
+                description: "Add a payment profile to a user (admin only)",
+                body: .type(PaymentProfileRequestDTO.self),
+                response: .type(PaymentProfileResponseDTO.self)
+            )
+
+        profiles.delete(":\(Self.profileIdParam)", use: self.deletePaymentProfile)
+            .openAPI(
+                summary: "Delete a payment profile",
+                description: "Delete a payment profile by id (admin only)",
+                statusCode: .noContent
+            )
+    }
+
+    @Sendable
+    func getUserPaymentProfiles(req: Request) async throws -> [PaymentProfileResponseDTO] {
+        let curUser = try req.auth.require(User.self)
+        let id = try curUser.requireID()
+
+        guard let userId = req.parameters.get(Self.userIdParam, as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing user ID parameter.")
+        }
+
+        guard curUser.isAdmin || userId == id else {
+            throw UserError.userNotAdmin
+        }
+
+        return try await req.paymentProfileService.getPaymentProfiles(for: userId)
+    }
+
+    @Sendable
+    func getPaymentProfile(req: Request) async throws -> PaymentProfileResponseDTO {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+
+        guard let profileId = req.parameters.get(Self.profileIdParam, as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing payment profile ID parameter.")
+        }
+
+        let profile = try await req.paymentProfileService.getPaymentProfile(for: profileId)
+        guard let profile else {
+            throw PaymentProfileError.paymentProfileNotFound
+        }
+
+        return profile
+    }
+
+    @Sendable
+    func addPaymentProfile(req: Request) async throws -> PaymentProfileResponseDTO {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+        let id = try curUser.requireID()
+
+        try PaymentProfileRequestDTO.validate(content: req)
+        let dto = try req.content.decode(PaymentProfileRequestDTO.self)
+
+        guard let userId = req.parameters.get("userID", as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing user ID parameter.")
+        }
+
+        return try await req.paymentProfileService.addPaymentProfile(asUser: id, from: dto, to: userId)
+    }
+
+    @Sendable
+    func deletePaymentProfile(req: Request) async throws -> HTTPStatus {
+        let curUser = try req.auth.require(User.self)
+        guard curUser.isAdmin else {
+            throw UserError.userNotAdmin
+        }
+        let id = try curUser.requireID()
+
+        guard let profileId = req.parameters.get(Self.profileIdParam, as: UUID.self) else {
+            throw Abort(.badRequest, reason: "Invalid or missing payment profile ID parameter.")
+        }
+
+        try await req.paymentProfileService.deletePaymentProfile(asUser: id, id: profileId)
+        return .noContent
+    }
+}

--- a/servers/Sources/MembersServer/DTOs/Requests/ApiKeys/ApiKeyRequestDTO.swift
+++ b/servers/Sources/MembersServer/DTOs/Requests/ApiKeys/ApiKeyRequestDTO.swift
@@ -1,0 +1,43 @@
+import Vapor
+import struct Foundation.Date
+import struct Foundation.UUID
+
+struct ApiKeyRequestDTO: Content {
+    let name: String
+    let expiresAt: Date?
+}
+
+extension ApiKeyRequestDTO: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("name", as: String.self, is: .count(1...100))
+    }
+}
+
+struct ApiKeyResponseDTO: Content {
+    let id: UUID
+    let userId: UUID
+    let name: String
+    let key: String
+    let isActive: Bool
+    let expiresAt: Date?
+    let createdAt: Date
+    let createdBy: UUID
+}
+
+extension ApiKey {
+    func toResponseDTO(withKey key: String) -> ApiKeyResponseDTO {
+        guard let id = self.id else {
+            fatalError("ApiKey id is missing")
+        }
+        return ApiKeyResponseDTO(
+            id: id,
+            userId: $user.id,
+            name: name,
+            key: key,
+            isActive: isActive,
+            expiresAt: expiresAt,
+            createdAt: createdAt ?? Date(),
+            createdBy: createdBy
+        )
+    }
+}

--- a/servers/Sources/MembersServer/DTOs/Requests/Donations/DonationRequestDTO.swift
+++ b/servers/Sources/MembersServer/DTOs/Requests/Donations/DonationRequestDTO.swift
@@ -1,0 +1,41 @@
+import Vapor
+import struct Foundation.UUID
+
+struct DonationRequestDTO: Content {
+    let userId: UUID?
+    let amountInCents: Int
+    let source: PaymentSource?
+    let externalId: String?
+    let purpose: String?
+    let notes: String?
+}
+
+extension DonationRequestDTO: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("amountInCents", as: Int.self, is: .range(0...))
+        validations.add("externalId", as: String.self, is: .count(1...500), required: false)
+        validations.add("purpose", as: String.self, is: .count(1...1000), required: false)
+        validations.add("notes", as: String.self, is: .count(1...5000), required: false)
+    }
+}
+
+extension DonationRequestDTO {
+    func toModel() -> Donation {
+        return Donation(
+            userId: userId,
+            amountInCents: amountInCents,
+            source: source,
+            externalId: externalId,
+            purpose: purpose,
+            notes: notes
+        )
+    }
+
+    func updateDonation(_ donation: Donation) {
+        donation.amountInCents = amountInCents
+        donation.source = source
+        donation.externalId = externalId
+        donation.purpose = purpose
+        donation.notes = notes
+    }
+}

--- a/servers/Sources/MembersServer/DTOs/Requests/PaymentProfiles/PaymentProfileRequestDTO.swift
+++ b/servers/Sources/MembersServer/DTOs/Requests/PaymentProfiles/PaymentProfileRequestDTO.swift
@@ -1,0 +1,24 @@
+import Vapor
+
+struct PaymentProfileRequestDTO: Content {
+    let source: PaymentSource
+    let externalId: String
+    let connectedBy: ConnectionMethod
+}
+
+extension PaymentProfileRequestDTO: Validatable {
+    static func validations(_ validations: inout Validations) {
+        validations.add("externalId", as: String.self, is: .count(1...500))
+    }
+}
+
+extension PaymentProfileRequestDTO {
+    func toModel(userId: UUID) -> PaymentProfile {
+        return PaymentProfile(
+            userId: userId,
+            source: source,
+            externalId: externalId,
+            connectedBy: connectedBy
+        )
+    }
+}

--- a/servers/Sources/MembersServer/DTOs/Responses/Donations/DonationResponseDTO.swift
+++ b/servers/Sources/MembersServer/DTOs/Responses/Donations/DonationResponseDTO.swift
@@ -1,0 +1,34 @@
+import struct Foundation.Date
+import struct Foundation.UUID
+import protocol Vapor.Content
+
+struct DonationResponseDTO: Content {
+    let id: UUID
+    let userId: UUID?
+    let amountInCents: Int
+    let source: PaymentSource?
+    let externalId: String?
+    let purpose: String?
+    let notes: String?
+    let createdAt: Date
+    let updatedAt: Date
+}
+
+extension Donation {
+    func toResponseDTO() throws -> DonationResponseDTO {
+        guard let id = self.id else {
+            throw ServerError.unexpectedError(reason: "Donation id is missing")
+        }
+        return DonationResponseDTO(
+            id: id,
+            userId: $user.id,
+            amountInCents: amountInCents,
+            source: source,
+            externalId: externalId,
+            purpose: purpose,
+            notes: notes,
+            createdAt: createdAt ?? Date(),
+            updatedAt: updatedAt ?? Date()
+        )
+    }
+}

--- a/servers/Sources/MembersServer/DTOs/Responses/PaymentProfiles/PaymentProfileResponseDTO.swift
+++ b/servers/Sources/MembersServer/DTOs/Responses/PaymentProfiles/PaymentProfileResponseDTO.swift
@@ -1,0 +1,30 @@
+import struct Foundation.Date
+import struct Foundation.UUID
+import protocol Vapor.Content
+
+struct PaymentProfileResponseDTO: Content {
+    let id: UUID
+    let userId: UUID
+    let source: PaymentSource
+    let externalId: String
+    let connectedBy: ConnectionMethod
+    let createdAt: Date
+    let updatedAt: Date
+}
+
+extension PaymentProfile {
+    func toResponseDTO() throws -> PaymentProfileResponseDTO {
+        guard let id = self.id else {
+            throw ServerError.unexpectedError(reason: "PaymentProfile id is missing")
+        }
+        return PaymentProfileResponseDTO(
+            id: id,
+            userId: $user.id,
+            source: source,
+            externalId: externalId,
+            connectedBy: connectedBy,
+            createdAt: createdAt ?? Date(),
+            updatedAt: updatedAt ?? Date()
+        )
+    }
+}

--- a/servers/Sources/MembersServer/Errors/ApiKeyError.swift
+++ b/servers/Sources/MembersServer/Errors/ApiKeyError.swift
@@ -1,0 +1,35 @@
+import Vapor
+
+enum ApiKeyError: Error {
+    case invalidApiKey
+    case apiKeyNotFound
+    case apiKeyExpired
+    case apiKeyInactive
+    case userNotFound
+}
+
+extension ApiKeyError: AbortError {
+    var status: HTTPResponseStatus {
+        switch self {
+        case .invalidApiKey, .apiKeyNotFound, .apiKeyExpired, .apiKeyInactive:
+            .unauthorized
+        case .userNotFound:
+            .notFound
+        }
+    }
+
+    var reason: String {
+        switch self {
+        case .invalidApiKey:
+            "Invalid API key."
+        case .apiKeyNotFound:
+            "API key not found."
+        case .apiKeyExpired:
+            "API key has expired."
+        case .apiKeyInactive:
+            "API key is inactive."
+        case .userNotFound:
+            "User not found."
+        }
+    }
+}

--- a/servers/Sources/MembersServer/Errors/DonationError.swift
+++ b/servers/Sources/MembersServer/Errors/DonationError.swift
@@ -1,0 +1,24 @@
+import Vapor
+
+enum DonationError: Error, Equatable {
+    case donationNotFound
+    case userNotFound
+}
+
+extension DonationError: AbortError {
+    var status: HTTPResponseStatus {
+        switch self {
+        case .donationNotFound, .userNotFound:
+            .notFound
+        }
+    }
+
+    var reason: String {
+        switch self {
+        case .donationNotFound:
+            "The donation you requested could not be found."
+        case .userNotFound:
+            "The user you specified could not be found."
+        }
+    }
+}

--- a/servers/Sources/MembersServer/Errors/PaymentProfileError.swift
+++ b/servers/Sources/MembersServer/Errors/PaymentProfileError.swift
@@ -1,0 +1,29 @@
+import Vapor
+
+enum PaymentProfileError: Error, Equatable {
+    case paymentProfileNotFound
+    case userNotFound
+    case uniqueViolation
+}
+
+extension PaymentProfileError: AbortError {
+    var status: HTTPResponseStatus {
+        switch self {
+        case .paymentProfileNotFound, .userNotFound:
+            .notFound
+        case .uniqueViolation:
+            .conflict
+        }
+    }
+
+    var reason: String {
+        switch self {
+        case .paymentProfileNotFound:
+            "The payment profile you requested could not be found."
+        case .userNotFound:
+            "The user you specified could not be found."
+        case .uniqueViolation:
+            "A payment profile with this source and external ID already exists."
+        }
+    }
+}

--- a/servers/Sources/MembersServer/Extensions/Request+Services.swift
+++ b/servers/Sources/MembersServer/Extensions/Request+Services.swift
@@ -24,4 +24,12 @@ extension Request {
     var userBadgeService: UserBadgeService {
         return UserBadgeService(database: self.db, adminLogger: self.adminLogService)
     }
+
+    var paymentProfileService: PaymentProfileService {
+        return PaymentProfileService(database: self.db, adminLogger: self.adminLogService)
+    }
+
+    var donationService: DonationService {
+        return DonationService(database: self.db, adminLogger: self.adminLogService)
+    }
 }

--- a/servers/Sources/MembersServer/Extensions/Request+Services.swift
+++ b/servers/Sources/MembersServer/Extensions/Request+Services.swift
@@ -32,4 +32,8 @@ extension Request {
     var donationService: DonationService {
         return DonationService(database: self.db, adminLogger: self.adminLogService)
     }
+
+    var apiKeyService: ApiKeyService {
+        return ApiKeyService(database: self.db, adminLogger: self.adminLogService)
+    }
 }

--- a/servers/Sources/MembersServer/Migrations/AddApiKeysMigration.swift
+++ b/servers/Sources/MembersServer/Migrations/AddApiKeysMigration.swift
@@ -1,0 +1,59 @@
+import Fluent
+import SQLKit
+
+struct AddApiKeysMigration: AsyncMigration {
+    private static let idxApiKeysUserId = "idx_api_keys_user_id"
+    private static let idxApiKeysHash = "idx_api_keys_key_hash"
+
+    func prepare(on database: any FluentKit.Database) async throws {
+        try await database.schema("api_keys")
+            .id()
+            .field(
+                "user_id",
+                .uuid,
+                .required,
+                .references("users", "id", onDelete: .cascade)
+            )
+            .field("name", .string, .required)
+            .field("key_hash", .string, .required)
+            .field("is_active", .bool, .required)
+            .field("expires_at", .datetime)
+            .field("created_by", .uuid, .required)
+            .field("created_at", .datetime, .required)
+            .field("updated_at", .datetime, .required)
+            .field("deleted_at", .datetime)
+            .create()
+
+        guard let sqlDatabase = database as? any SQLDatabase else {
+            fatalError("Attempting to use sql migration on non sql database")
+        }
+
+        try await sqlDatabase
+            .create(index: Self.idxApiKeysUserId)
+            .on("api_keys")
+            .column("user_id")
+            .run()
+
+        try await sqlDatabase
+            .create(index: Self.idxApiKeysHash)
+            .on("api_keys")
+            .column("key_hash")
+            .run()
+    }
+
+    func revert(on database: any FluentKit.Database) async throws {
+        guard let sqlDatabase = database as? any SQLDatabase else {
+            fatalError("Attempting to use sql migration on non sql database")
+        }
+
+        try await sqlDatabase
+            .drop(index: Self.idxApiKeysHash)
+            .run()
+
+        try await sqlDatabase
+            .drop(index: Self.idxApiKeysUserId)
+            .run()
+
+        try await database.schema("api_keys").delete()
+    }
+}

--- a/servers/Sources/MembersServer/Migrations/AddDonationsMigration.swift
+++ b/servers/Sources/MembersServer/Migrations/AddDonationsMigration.swift
@@ -1,0 +1,78 @@
+import Fluent
+import SQLKit
+
+struct AddDonationsMigration: AsyncMigration {
+    private static let idxPaymentProfilesUserId = "idx_payment_profiles_user_id"
+    private static let idxDonationsUserId = "idx_donations_user_id"
+    private static let idxDonationsCreatedAt = "idx_donations_created_at"
+
+    func prepare(on database: any FluentKit.Database) async throws {
+        try await database.schema(PaymentProfile.schema)
+            .id()
+            .field(PaymentProfile.fieldUserId, .uuid, .required, .references(User.schema, User.fieldId, onDelete: .cascade))
+            .field(PaymentProfile.fieldSource, .string, .required)
+            .field(PaymentProfile.fieldExternalId, .string, .required)
+            .field(PaymentProfile.fieldConnectedBy, .string, .required)
+            .field(PaymentProfile.fieldCreatedAt, .datetime, .required)
+            .field(PaymentProfile.fieldUpdatedAt, .datetime, .required)
+            .field(PaymentProfile.fieldDeletedAt, .datetime)
+            .unique(on: PaymentProfile.fieldSource, PaymentProfile.fieldExternalId)
+            .create()
+
+        try await database.schema(Donation.schema)
+            .id()
+            .field(Donation.fieldUserId, .uuid, .references(User.schema, User.fieldId, onDelete: .setNull))
+            .field(Donation.fieldAmountInCents, .int, .required)
+            .field(Donation.fieldSource, .string)
+            .field(Donation.fieldExternalId, .string)
+            .field(Donation.fieldPurpose, .string)
+            .field(Donation.fieldNotes, .string)
+            .field(Donation.fieldCreatedAt, .datetime, .required)
+            .field(Donation.fieldUpdatedAt, .datetime, .required)
+            .field(Donation.fieldDeletedAt, .datetime)
+            .create()
+
+        guard let sqlDatabase = database as? any SQLDatabase else {
+            fatalError("Attempting to use sql migration on non sql database")
+        }
+
+        try await sqlDatabase
+            .create(index: Self.idxPaymentProfilesUserId)
+            .on(PaymentProfile.schema)
+            .column(PaymentProfile.fieldUserId.description)
+            .run()
+
+        try await sqlDatabase
+            .create(index: Self.idxDonationsUserId)
+            .on(Donation.schema)
+            .column(Donation.fieldUserId.description)
+            .run()
+
+        try await sqlDatabase
+            .create(index: Self.idxDonationsCreatedAt)
+            .on(Donation.schema)
+            .column(Donation.fieldCreatedAt.description)
+            .run()
+    }
+
+    func revert(on database: any FluentKit.Database) async throws {
+        guard let sqlDatabase = database as? any SQLDatabase else {
+            fatalError("Attempting to use sql migration on non sql database")
+        }
+
+        try await sqlDatabase
+            .drop(index: Self.idxDonationsCreatedAt)
+            .run()
+
+        try await sqlDatabase
+            .drop(index: Self.idxDonationsUserId)
+            .run()
+
+        try await sqlDatabase
+            .drop(index: Self.idxPaymentProfilesUserId)
+            .run()
+
+        try await database.schema(Donation.schema).delete()
+        try await database.schema(PaymentProfile.schema).delete()
+    }
+}

--- a/servers/Sources/MembersServer/Migrations/AddDonationsMigration.swift
+++ b/servers/Sources/MembersServer/Migrations/AddDonationsMigration.swift
@@ -9,7 +9,12 @@ struct AddDonationsMigration: AsyncMigration {
     func prepare(on database: any FluentKit.Database) async throws {
         try await database.schema(PaymentProfile.schema)
             .id()
-            .field(PaymentProfile.fieldUserId, .uuid, .required, .references(User.schema, User.fieldId, onDelete: .cascade))
+            .field(
+                PaymentProfile.fieldUserId,
+                .uuid,
+                .required,
+                .references(User.schema, User.fieldId, onDelete: .cascade)
+            )
             .field(PaymentProfile.fieldSource, .string, .required)
             .field(PaymentProfile.fieldExternalId, .string, .required)
             .field(PaymentProfile.fieldConnectedBy, .string, .required)

--- a/servers/Sources/MembersServer/Models/ApiKey.swift
+++ b/servers/Sources/MembersServer/Models/ApiKey.swift
@@ -1,0 +1,80 @@
+import Crypto
+import Fluent
+
+import struct Foundation.Data
+import struct Foundation.Date
+import struct Foundation.UUID
+
+final class ApiKey: Model, @unchecked Sendable {
+    static let schema = "api_keys"
+
+    static let fieldId = DbConstants.idField
+    static let fieldUserId = DbConstants.userIdRelation
+    static let fieldName = DbConstants.nameField
+    static let fieldKeyHash: FieldKey = "key_hash"
+    static let fieldIsActive: FieldKey = "is_active"
+    static let fieldExpiresAt: FieldKey = "expires_at"
+    static let fieldCreatedBy: FieldKey = "created_by"
+    static let fieldCreatedAt = DbConstants.createdAtField
+    static let fieldUpdatedAt = DbConstants.updatedAtField
+    static let fieldDeletedAt = DbConstants.deletedAtField
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Parent(key: fieldUserId)
+    var user: User
+
+    @Field(key: fieldName)
+    var name: String
+
+    @Field(key: fieldKeyHash)
+    var keyHash: String
+
+    @Field(key: fieldIsActive)
+    var isActive: Bool
+
+    @OptionalField(key: fieldExpiresAt)
+    var expiresAt: Date?
+
+    @Field(key: fieldCreatedBy)
+    var createdBy: UUID
+
+    @Timestamp(key: fieldCreatedAt, on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: fieldUpdatedAt, on: .update)
+    var updatedAt: Date?
+
+    @Timestamp(key: fieldDeletedAt, on: .delete)
+    var deletedAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        userId: UUID,
+        name: String,
+        keyHash: String,
+        isActive: Bool = true,
+        expiresAt: Date? = nil,
+        createdBy: UUID
+    ) {
+        self.id = id
+        self.$user.id = userId
+        self.name = name
+        self.keyHash = keyHash
+        self.isActive = isActive
+        self.expiresAt = expiresAt
+        self.createdBy = createdBy
+    }
+}
+
+extension ApiKey {
+    func verify(key: String) -> Bool {
+        let data = Data(key.utf8)
+        let hashedData = SHA256.hash(data: data)
+        let hashedKeyString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
+        return hashedKeyString == keyHash
+    }
+}

--- a/servers/Sources/MembersServer/Models/Donation.swift
+++ b/servers/Sources/MembersServer/Models/Donation.swift
@@ -1,0 +1,71 @@
+import Fluent
+
+import struct Foundation.Date
+import struct Foundation.UUID
+
+final class Donation: Model, @unchecked Sendable {
+    static let schema = "donations"
+
+    static let fieldId = DbConstants.idField
+    static let fieldUserId = DbConstants.userIdRelation
+    static let fieldAmountInCents = DbConstants.amountInCentsField
+    static let fieldSource = DbConstants.sourceField
+    static let fieldExternalId = DbConstants.externalIdField
+    static let fieldPurpose = DbConstants.purposeField
+    static let fieldNotes = DbConstants.notesField
+    static let fieldCreatedAt = DbConstants.createdAtField
+    static let fieldUpdatedAt = DbConstants.updatedAtField
+    static let fieldDeletedAt = DbConstants.deletedAtField
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @OptionalParent(key: fieldUserId)
+    var user: User?
+
+    @Field(key: fieldAmountInCents)
+    var amountInCents: Int
+
+    @OptionalEnum(key: fieldSource)
+    var source: PaymentSource?
+
+    @Field(key: fieldExternalId)
+    var externalId: String?
+
+    @Field(key: fieldPurpose)
+    var purpose: String?
+
+    @Field(key: fieldNotes)
+    var notes: String?
+
+    @Timestamp(key: fieldCreatedAt, on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: fieldUpdatedAt, on: .update)
+    var updatedAt: Date?
+
+    @Timestamp(key: fieldDeletedAt, on: .delete)
+    var deletedAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        userId: UUID? = nil,
+        amountInCents: Int,
+        source: PaymentSource? = nil,
+        externalId: String? = nil,
+        purpose: String? = nil,
+        notes: String? = nil
+    ) {
+        self.id = id
+        if let userId {
+            self.$user.id = userId
+        }
+        self.amountInCents = amountInCents
+        self.source = source
+        self.externalId = externalId
+        self.purpose = purpose
+        self.notes = notes
+    }
+}

--- a/servers/Sources/MembersServer/Models/PaymentProfile.swift
+++ b/servers/Sources/MembersServer/Models/PaymentProfile.swift
@@ -57,15 +57,15 @@ final class PaymentProfile: Model, @unchecked Sendable {
 }
 
 enum PaymentSource: String, Codable {
-    case zeffy = "Zeffy"
-    case zelle = "Zelle"
-    case paypal = "PayPal"
-    case cash = "Cash"
-    case check = "Check"
+    case zeffy
+    case zelle
+    case paypal
+    case cash
+    case check
 }
 
 enum ConnectionMethod: String, Codable {
-    case email = "email"
-    case api = "api"
-    case user = "user"
+    case email
+    case api
+    case user
 }

--- a/servers/Sources/MembersServer/Models/PaymentProfile.swift
+++ b/servers/Sources/MembersServer/Models/PaymentProfile.swift
@@ -1,0 +1,71 @@
+import Fluent
+
+import struct Foundation.Date
+import struct Foundation.UUID
+
+final class PaymentProfile: Model, @unchecked Sendable {
+    static let schema = "payment_profiles"
+
+    static let fieldId = DbConstants.idField
+    static let fieldUserId = DbConstants.userIdRelation
+    static let fieldSource = DbConstants.sourceField
+    static let fieldExternalId = DbConstants.externalIdField
+    static let fieldConnectedBy = DbConstants.connectedByField
+    static let fieldCreatedAt = DbConstants.createdAtField
+    static let fieldUpdatedAt = DbConstants.updatedAtField
+    static let fieldDeletedAt = DbConstants.deletedAtField
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Parent(key: fieldUserId)
+    var user: User
+
+    @Enum(key: fieldSource)
+    var source: PaymentSource
+
+    @Field(key: fieldExternalId)
+    var externalId: String
+
+    @Enum(key: fieldConnectedBy)
+    var connectedBy: ConnectionMethod
+
+    @Timestamp(key: fieldCreatedAt, on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: fieldUpdatedAt, on: .update)
+    var updatedAt: Date?
+
+    @Timestamp(key: fieldDeletedAt, on: .delete)
+    var deletedAt: Date?
+
+    init() {}
+
+    init(
+        id: UUID? = nil,
+        userId: UUID,
+        source: PaymentSource,
+        externalId: String,
+        connectedBy: ConnectionMethod
+    ) {
+        self.id = id
+        self.$user.id = userId
+        self.source = source
+        self.externalId = externalId
+        self.connectedBy = connectedBy
+    }
+}
+
+enum PaymentSource: String, Codable {
+    case zeffy = "Zeffy"
+    case zelle = "Zelle"
+    case paypal = "PayPal"
+    case cash = "Cash"
+    case check = "Check"
+}
+
+enum ConnectionMethod: String, Codable {
+    case email = "email"
+    case api = "api"
+    case user = "user"
+}

--- a/servers/Sources/MembersServer/Models/User.swift
+++ b/servers/Sources/MembersServer/Models/User.swift
@@ -130,6 +130,9 @@ final class User: Model, Authenticatable, @unchecked Sendable {
     @Children(for: \.$user)
     var donations: [Donation]
 
+    @Children(for: \.$user)
+    var apiKeys: [ApiKey]
+
     // Computed Vars
 
     var fullName: String {

--- a/servers/Sources/MembersServer/Models/User.swift
+++ b/servers/Sources/MembersServer/Models/User.swift
@@ -124,6 +124,12 @@ final class User: Model, Authenticatable, @unchecked Sendable {
     @Children(for: \.$user)
     var badges: [UserBadge]
 
+    @Children(for: \.$user)
+    var paymentProfiles: [PaymentProfile]
+
+    @Children(for: \.$user)
+    var donations: [Donation]
+
     // Computed Vars
 
     var fullName: String {

--- a/servers/Sources/MembersServer/Services/ApiKeyService.swift
+++ b/servers/Sources/MembersServer/Services/ApiKeyService.swift
@@ -1,0 +1,134 @@
+import Crypto
+import Fluent
+
+import struct Foundation.Data
+import struct Foundation.Date
+
+struct ApiKeyService {
+    private let database: any Database
+    private let adminLogger: AdminLogService
+
+    init(database: any Database, adminLogger: AdminLogService) {
+        self.database = database
+        self.adminLogger = adminLogger
+    }
+
+    func getApiKey(for id: UUID) async throws -> ApiKeyResponseDTO? {
+        let apiKey = try await ApiKey.query(on: database)
+            .filter(\.$id == id)
+            .with(\.$user)
+            .first()
+
+        guard let apiKey else {
+            return nil
+        }
+
+        return apiKey.toResponseDTO(withKey: "")
+    }
+
+    func getApiKeys(for userId: UUID) async throws -> [ApiKeyResponseDTO] {
+        let apiKeys = try await ApiKey.query(on: database)
+            .filter(\.$user.$id == userId)
+            .sort(\.$createdAt, .descending)
+            .all()
+
+        return apiKeys.map { $0.toResponseDTO(withKey: "") }
+    }
+
+    func createApiKey(
+        asUser: UUID,
+        for userId: UUID,
+        from dto: ApiKeyRequestDTO
+    ) async throws -> ApiKeyResponseDTO {
+        let userExists = try await User.query(on: database).filter(\.$id == userId).first()
+        guard userExists != nil else {
+            throw ApiKeyError.userNotFound
+        }
+
+        let key = generateApiKey()
+        let hashedKey = hashKey(key)
+
+        let apiKey = ApiKey(
+            userId: userId,
+            name: dto.name,
+            keyHash: hashedKey,
+            isActive: true,
+            expiresAt: dto.expiresAt,
+            createdBy: asUser
+        )
+
+        return try await database.transaction { tDb in
+            try await apiKey.save(on: tDb)
+
+            guard let apiKeyId = apiKey.id else {
+                throw ServerError.unexpectedError(reason: "ApiKey ID is nil after save")
+            }
+
+            try await adminLogger.addLog(
+                for: asUser,
+                on: tDb,
+                "Created API key \(apiKeyId) named \(dto.name) for user \(userId)"
+            )
+
+            let createdApiKey = try await ApiKey.query(on: tDb)
+                .filter(\.$id == apiKeyId)
+                .with(\.$user)
+                .first()
+
+            guard let createdApiKey else {
+                throw ServerError.unexpectedError(
+                    reason: "Created API key returned nil"
+                )
+            }
+
+            return createdApiKey.toResponseDTO(withKey: key)
+        }
+    }
+
+    func deleteApiKey(asUser: UUID, id: UUID) async throws {
+        try await database.transaction { tDb in
+            let apiKey = try await ApiKey.query(on: tDb)
+                .filter(\.$id == id)
+                .first()
+
+            guard let apiKey else {
+                throw ApiKeyError.apiKeyNotFound
+            }
+
+            try await apiKey.delete(on: tDb)
+
+            try await adminLogger.addLog(for: asUser, on: tDb, "Deleted API key \(id)")
+        }
+    }
+
+    func verifyApiKey(_ key: String) async throws -> ApiKey {
+        let hashedKey = hashKey(key)
+
+        guard let apiKey = try await ApiKey.query(on: database)
+            .filter(\.$keyHash == hashedKey)
+            .filter(\.$isActive == true)
+            .first() else {
+            throw ApiKeyError.invalidApiKey
+        }
+
+        if !apiKey.isActive {
+            throw ApiKeyError.apiKeyInactive
+        }
+
+        if let expiresAt = apiKey.expiresAt, expiresAt < Date() {
+            throw ApiKeyError.apiKeyExpired
+        }
+
+        return apiKey
+    }
+
+    private func generateApiKey() -> String {
+        return "hsl_" + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+    }
+
+    private func hashKey(_ key: String) -> String {
+        let data = Data(key.utf8)
+        let hashedData = SHA256.hash(data: data)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/servers/Sources/MembersServer/Services/DonationService.swift
+++ b/servers/Sources/MembersServer/Services/DonationService.swift
@@ -53,7 +53,11 @@ struct DonationService {
                 throw ServerError.unexpectedError(reason: "Donation ID is nil after save")
             }
 
-            try await adminLogger.addLog(for: asUser, on: tDb, "Added donation \(donationId) for \(donation.amountInCents) cents")
+            try await adminLogger.addLog(
+                for: asUser,
+                on: tDb,
+                "Added donation \(donationId) for \(donation.amountInCents) cents"
+            )
 
             let createdDonation = try await Donation.query(on: tDb)
                 .filter(\.$id == donationId)
@@ -61,7 +65,9 @@ struct DonationService {
                 .first()
 
             guard let createdDonation else {
-                throw ServerError.unexpectedError(reason: "Created donation returned nil")
+                throw ServerError.unexpectedError(
+                    reason: "Created donation returned nil"
+                )
             }
 
             return try createdDonation.toResponseDTO()

--- a/servers/Sources/MembersServer/Services/DonationService.swift
+++ b/servers/Sources/MembersServer/Services/DonationService.swift
@@ -1,0 +1,106 @@
+import Fluent
+
+struct DonationService {
+    private let database: any Database
+    private let adminLogger: AdminLogService
+
+    init(database: any Database, adminLogger: AdminLogService) {
+        self.database = database
+        self.adminLogger = adminLogger
+    }
+
+    func getDonation(for id: UUID) async throws -> DonationResponseDTO? {
+        let donation = try await Donation.query(on: database)
+            .filter(\.$id == id)
+            .with(\.$user)
+            .first()
+
+        return try donation?.toResponseDTO()
+    }
+
+    func getAllDonations() async throws -> [DonationResponseDTO] {
+        let donations = try await Donation.query(on: database)
+            .sort(\.$createdAt, .descending)
+            .with(\.$user)
+            .all()
+
+        return try donations.map { try $0.toResponseDTO() }
+    }
+
+    func getDonations(for userId: UUID) async throws -> [DonationResponseDTO] {
+        let donations = try await Donation.query(on: database)
+            .filter(\.$user.$id == userId)
+            .sort(\.$createdAt, .descending)
+            .all()
+
+        return try donations.map { try $0.toResponseDTO() }
+    }
+
+    func addDonation(asUser: UUID, from dto: DonationRequestDTO) async throws -> DonationResponseDTO {
+        if let userId = dto.userId {
+            let userExists = try await User.query(on: database).filter(\.$id == userId).first()
+            guard userExists != nil else {
+                throw DonationError.userNotFound
+            }
+        }
+
+        let donation = dto.toModel()
+
+        return try await database.transaction { tDb in
+            try await donation.save(on: tDb)
+
+            guard let donationId = donation.id else {
+                throw ServerError.unexpectedError(reason: "Donation ID is nil after save")
+            }
+
+            try await adminLogger.addLog(for: asUser, on: tDb, "Added donation \(donationId) for \(donation.amountInCents) cents")
+
+            let createdDonation = try await Donation.query(on: tDb)
+                .filter(\.$id == donationId)
+                .with(\.$user)
+                .first()
+
+            guard let createdDonation else {
+                throw ServerError.unexpectedError(reason: "Created donation returned nil")
+            }
+
+            return try createdDonation.toResponseDTO()
+        }
+    }
+
+    func updateDonation(asUser: UUID, from dto: DonationRequestDTO, for id: UUID) async throws -> DonationResponseDTO {
+        let donation = try await Donation.query(on: database)
+            .filter(\.$id == id)
+            .with(\.$user)
+            .first()
+
+        guard let donation else {
+            throw DonationError.donationNotFound
+        }
+
+        dto.updateDonation(donation)
+
+        try await database.transaction { tDb in
+            try await donation.save(on: tDb)
+            try await adminLogger.addLog(for: asUser, on: tDb, "Updated donation \(id)")
+        }
+
+        return try donation.toResponseDTO()
+    }
+
+    func deleteDonation(asUser: UUID, id: UUID) async throws {
+        try await database.transaction { tDb in
+            let donation = try await Donation.query(on: tDb)
+                .filter(\.$id == id)
+                .first()
+
+            guard let donation else {
+                throw DonationError.donationNotFound
+            }
+
+            try await donation.delete(on: tDb)
+
+            try await adminLogger.addLog(for: asUser, on: tDb, "Deleted donation \(id)")
+        }
+    }
+}

--- a/servers/Sources/MembersServer/Services/PaymentProfileService.swift
+++ b/servers/Sources/MembersServer/Services/PaymentProfileService.swift
@@ -1,0 +1,83 @@
+import Fluent
+
+struct PaymentProfileService {
+    private let database: any Database
+    private let adminLogger: AdminLogService
+
+    init(database: any Database, adminLogger: AdminLogService) {
+        self.database = database
+        self.adminLogger = adminLogger
+    }
+
+    func getPaymentProfile(for id: UUID) async throws -> PaymentProfileResponseDTO? {
+        let profile = try await PaymentProfile.query(on: database)
+            .filter(\.$id == id)
+            .with(\.$user)
+            .first()
+
+        return try profile?.toResponseDTO()
+    }
+
+    func getPaymentProfiles(for userId: UUID) async throws -> [PaymentProfileResponseDTO] {
+        let profiles = try await PaymentProfile.query(on: database)
+            .filter(\.$user.$id == userId)
+            .sort(\.$createdAt, .descending)
+            .all()
+
+        return try profiles.map { try $0.toResponseDTO() }
+    }
+
+    func addPaymentProfile(asUser: UUID, from dto: PaymentProfileRequestDTO, to userId: UUID) async throws -> PaymentProfileResponseDTO {
+        let userExists = try await User.query(on: database).filter(\.$id == userId).first()
+        guard userExists != nil else {
+            throw PaymentProfileError.userNotFound
+        }
+
+        let profile = dto.toModel(userId: userId)
+
+        return try await database.transaction { tDb in
+            do {
+                try await profile.save(on: tDb)
+            } catch {
+                guard let dbError = error as? any DatabaseError,
+                      dbError.isConstraintFailure else {
+                    throw error
+                }
+                throw PaymentProfileError.uniqueViolation
+            }
+
+            guard let profileId = profile.id else {
+                throw ServerError.unexpectedError(reason: "PaymentProfile ID is nil after save")
+            }
+
+            try await adminLogger.addLog(for: asUser, on: tDb, "Added payment profile \(profileId) with source \(profile.source.rawValue) for user \(userId)")
+
+            let createdProfile = try await PaymentProfile.query(on: tDb)
+                .filter(\.$id == profileId)
+                .with(\.$user)
+                .first()
+
+            guard let createdProfile else {
+                throw ServerError.unexpectedError(reason: "Created payment profile returned nil")
+            }
+
+            return try createdProfile.toResponseDTO()
+        }
+    }
+
+    func deletePaymentProfile(asUser: UUID, id: UUID) async throws {
+        try await database.transaction { tDb in
+            let profile = try await PaymentProfile.query(on: tDb)
+                .filter(\.$id == id)
+                .first()
+
+            guard let profile else {
+                throw PaymentProfileError.paymentProfileNotFound
+            }
+
+            try await profile.delete(on: tDb)
+
+            try await adminLogger.addLog(for: asUser, on: tDb, "Deleted payment profile \(id)")
+        }
+    }
+}

--- a/servers/Sources/MembersServer/Services/PaymentProfileService.swift
+++ b/servers/Sources/MembersServer/Services/PaymentProfileService.swift
@@ -27,7 +27,11 @@ struct PaymentProfileService {
         return try profiles.map { try $0.toResponseDTO() }
     }
 
-    func addPaymentProfile(asUser: UUID, from dto: PaymentProfileRequestDTO, to userId: UUID) async throws -> PaymentProfileResponseDTO {
+    func addPaymentProfile(
+        asUser: UUID,
+        from dto: PaymentProfileRequestDTO,
+        to userId: UUID
+    ) async throws -> PaymentProfileResponseDTO {
         let userExists = try await User.query(on: database).filter(\.$id == userId).first()
         guard userExists != nil else {
             throw PaymentProfileError.userNotFound
@@ -50,7 +54,11 @@ struct PaymentProfileService {
                 throw ServerError.unexpectedError(reason: "PaymentProfile ID is nil after save")
             }
 
-            try await adminLogger.addLog(for: asUser, on: tDb, "Added payment profile \(profileId) with source \(profile.source.rawValue) for user \(userId)")
+            try await adminLogger.addLog(
+                for: asUser,
+                on: tDb,
+                "Added payment profile \(profileId) with source \(profile.source.rawValue) for user \(userId)"
+            )
 
             let createdProfile = try await PaymentProfile.query(on: tDb)
                 .filter(\.$id == profileId)
@@ -58,7 +66,9 @@ struct PaymentProfileService {
                 .first()
 
             guard let createdProfile else {
-                throw ServerError.unexpectedError(reason: "Created payment profile returned nil")
+                throw ServerError.unexpectedError(
+                    reason: "Created payment profile returned nil"
+                )
             }
 
             return try createdProfile.toResponseDTO()

--- a/servers/Sources/MembersServer/Utils/Constants/DbConstants.swift
+++ b/servers/Sources/MembersServer/Utils/Constants/DbConstants.swift
@@ -15,6 +15,16 @@ enum DbConstants {
     static let badgesIdRelation: FieldKey = "badge_id"
     static let membershipLevelIdRelation: FieldKey = "membership_level_id"
 
+    // Payment Profile Fields
+    static let sourceField: FieldKey = "source"
+    static let externalIdField: FieldKey = "external_id"
+    static let connectedByField: FieldKey = "connected_by"
+
+    // Donation Fields
+    static let amountInCentsField: FieldKey = "amount_in_cents"
+    static let purposeField: FieldKey = "purpose"
+    static let notesField: FieldKey = "notes"
+
     // Removed Tables
     static let orientationsTable = "orientations"
 }

--- a/servers/Sources/MembersServer/configure.swift
+++ b/servers/Sources/MembersServer/configure.swift
@@ -27,7 +27,14 @@ public func configure(_ app: Application) async throws {
             ), as: .psql)
     }
 
-    app.migrations.add(CreateInitialSchema(), AddBadgesMigration(), AddUserIndicies(), AddAdminLogMigration(), AddDonationsMigration(), AddApiKeysMigration())
+    app.migrations.add(
+        CreateInitialSchema(),
+        AddBadgesMigration(),
+        AddUserIndicies(),
+        AddAdminLogMigration(),
+        AddDonationsMigration(),
+        AddApiKeysMigration()
+    )
     try await app.autoMigrate()
 
     // region JWT Configuration

--- a/servers/Sources/MembersServer/configure.swift
+++ b/servers/Sources/MembersServer/configure.swift
@@ -27,7 +27,7 @@ public func configure(_ app: Application) async throws {
             ), as: .psql)
     }
 
-    app.migrations.add(CreateInitialSchema(), AddBadgesMigration(), AddUserIndicies(), AddAdminLogMigration())
+    app.migrations.add(CreateInitialSchema(), AddBadgesMigration(), AddUserIndicies(), AddAdminLogMigration(), AddDonationsMigration())
     try await app.autoMigrate()
 
     // region JWT Configuration

--- a/servers/Sources/MembersServer/configure.swift
+++ b/servers/Sources/MembersServer/configure.swift
@@ -27,7 +27,7 @@ public func configure(_ app: Application) async throws {
             ), as: .psql)
     }
 
-    app.migrations.add(CreateInitialSchema(), AddBadgesMigration(), AddUserIndicies(), AddAdminLogMigration(), AddDonationsMigration())
+    app.migrations.add(CreateInitialSchema(), AddBadgesMigration(), AddUserIndicies(), AddAdminLogMigration(), AddDonationsMigration(), AddApiKeysMigration())
     try await app.autoMigrate()
 
     // region JWT Configuration

--- a/servers/Sources/MembersServer/routes.swift
+++ b/servers/Sources/MembersServer/routes.swift
@@ -34,4 +34,6 @@ func routes(_ app: Application) throws {
     try openApiProtected.register(collection: InstructorsController())
     try openApiProtected.register(collection: AdminLogsController())
     try openApiProtected.register(collection: UserBadgesController())
+    try openApiProtected.register(collection: PaymentProfilesController())
+    try openApiProtected.register(collection: DonationsController())
 }

--- a/servers/Sources/MembersServer/routes.swift
+++ b/servers/Sources/MembersServer/routes.swift
@@ -34,6 +34,8 @@ func routes(_ app: Application) throws {
     try openApiProtected.register(collection: InstructorsController())
     try openApiProtected.register(collection: AdminLogsController())
     try openApiProtected.register(collection: UserBadgesController())
+    try openApiProtected.register(collection: ApiKeysController())
     try openApiProtected.register(collection: PaymentProfilesController())
     try openApiProtected.register(collection: DonationsController())
+    try app.register(collection: ExternalDonationsController())
 }


### PR DESCRIPTION
I wanted a way to track donations. The internal bookeeping will largely be handled by 3rd party processes, ie parsing Zelle emails with n8n to update the donations history. Users or admins can create payment profiles that track the external ID in the payment system (ie for Zelle it'd just be their name in Zelle, but we know that after the first transaction and it should be trivial for a human to manage that for ~100 members.

## Summary
- Add PaymentProfile model to track external payment provider connections (Zeffy, Zelle, PayPal, Cash, Check)
- Add Donation model to track donations/payments with amountInCents storage
- Both models use soft deletes for audit purposes and log all admin actions
- Follows existing codebase patterns (services, controllers, DTOs)

## New Models

### PaymentProfile
- Links to existing `users` table 
- Tracks payment source (Zeffy, Zelle, PayPal, Cash, Check)
- Tracks external ID in the payment system
- Tracks how profile was connected (email address of creator, api, user)
- Unique constraint on (source, externalId) prevents duplicates

### Donation
- Links to users with nullable FK (supports anonymous donations)
- Stores amount in cents (consistent with MembershipLevel.costInCents)
- Tracks source, purpose, notes, and external transaction ID

## New API Endpoints

### Payment Profiles
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/v1/users/:userID/payment-profiles` | Self or Admin | List user's profiles |
| POST | `/v1/payment-profiles` | Admin | Add profile to user |
| GET | `/v1/payment-profiles/:id` | Admin | Get by ID |
| DELETE | `/v1/payment-profiles/:id` | Admin | Delete profile |

### Donations
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/v1/donations` | Admin | List all |
| GET | `/v1/donations/:id` | Admin | Get by ID |
| POST | `/v1/donations` | Admin | Create donation |
| PUT | `/v1/donations/:id` | Admin | Update donation |
| DELETE | `/v1/donations/:id` | Admin | Delete donation |
| GET | `/v1/users/:userID/donations` | Self or Admin | List user's donations |

## Files Added
- 14 new files (models, services, controllers, DTOs, errors, migration)

## Files Modified
- `DbConstants.swift` - Added new field key constants
- `User.swift` - Added `@Children` relations for paymentProfiles and donations
- `Request+Services.swift` - Added service accessors
- `routes.swift` - Registered new controllers
- `configure.swift` - Added migration

## Migration
- Creates `payment_profiles` and `donations` tables
- Adds indexes on `user_id` and `created_at` for performance
- Uses soft deletes via `deleted_at` timestamps