### PR TITLE
Add webhook notification for member registration

### DIFF
--- a/servers/.env.example
+++ b/servers/.env.example
@@ -7,3 +7,9 @@ POSTGRES_DB=heatsync
 # JWT Config
 # It's fully public, so safe to commit in example
 SUPABASE_JWK='{"x":"F8JJ68df7ShLJVnck6y5HXKqIhMofxad2t5T_hJIWp4","y":"lkTxAAyDVJR_oi6AFCF3kxbhnOpKSZNsDDWxN3jhwcQ","alg":"ES256","crv":"P-256","ext":true,"kid":"8fd11970-3df4-4347-a141-56dce2f9902a","kty":"EC","key_ops":["verify"]}'
+
+# Webhook Config (optional)
+# URL to send member registration webhooks to
+MEMBER_WEBHOOK_URL=https://n8n-cool-mountain-9401.fly.dev/webhook/d58c2a96-33fc-44e8-839c-7499f92c7d47
+# Secret used to sign webhook payloads (HMAC-SHA256)
+MEMBER_WEBHOOK_SECRET=

--- a/servers/.env.example
+++ b/servers/.env.example
@@ -10,6 +10,6 @@ SUPABASE_JWK='{"x":"F8JJ68df7ShLJVnck6y5HXKqIhMofxad2t5T_hJIWp4","y":"lkTxAAyDVJ
 
 # Webhook Config (optional)
 # URL to send member registration webhooks to
-MEMBER_WEBHOOK_URL=https://n8n-cool-mountain-9401.fly.dev/webhook/d58c2a96-33fc-44e8-839c-7499f92c7d47
+MEMBER_WEBHOOK_URL=
 # Secret used to sign webhook payloads (HMAC-SHA256)
 MEMBER_WEBHOOK_SECRET=

--- a/servers/Sources/MembersServer/Extensions/Request+Services.swift
+++ b/servers/Sources/MembersServer/Extensions/Request+Services.swift
@@ -2,7 +2,7 @@ import Vapor
 
 extension Request {
     var userService: UserService {
-        return UserService(database: self.db)
+        return UserService(database: self.db, webhookService: self.webhookService)
     }
 
     var badgeService: BadgeService {
@@ -23,5 +23,14 @@ extension Request {
 
     var userBadgeService: UserBadgeService {
         return UserBadgeService(database: self.db, adminLogger: self.adminLogService)
+    }
+
+    var webhookService: WebhookService {
+        return WebhookService(
+            client: self.client,
+            logger: self.logger,
+            webhookURL: Environment.get("MEMBER_WEBHOOK_URL"),
+            webhookSecret: Environment.get("MEMBER_WEBHOOK_SECRET")
+        )
     }
 }

--- a/servers/Sources/MembersServer/Services/WebhookService.swift
+++ b/servers/Sources/MembersServer/Services/WebhookService.swift
@@ -1,0 +1,84 @@
+import Crypto
+import Foundation
+import Vapor
+
+struct WebhookService {
+    private let client: any Client
+    private let logger: Logger
+    private let webhookURL: String?
+    private let webhookSecret: String?
+
+    init(client: any Client, logger: Logger, webhookURL: String?, webhookSecret: String?) {
+        self.client = client
+        self.logger = logger
+        self.webhookURL = webhookURL
+        self.webhookSecret = webhookSecret
+    }
+
+    func sendMemberRegisteredWebhook(for user: User) async {
+        guard let webhookURL, !webhookURL.isEmpty else {
+            logger.debug("Webhook URL not configured, skipping member registration webhook")
+            return
+        }
+
+        let payload = MemberRegisteredPayload(
+            event: "member.registered",
+            timestamp: ISO8601DateFormatter().string(from: Date()),
+            data: MemberRegisteredPayload.MemberData(
+                id: user.id?.uuidString ?? "",
+                firstName: user.firstName,
+                lastName: user.lastName,
+                email: user.email,
+                membershipLevel: user.membershipLevel?.$membershipLevel.value?.name
+            )
+        )
+
+        do {
+            let jsonData = try JSONEncoder().encode(payload)
+            let signature = generateSignature(for: jsonData)
+
+            var headers = HTTPHeaders()
+            headers.add(name: .contentType, value: "application/json")
+            if let signature {
+                headers.add(name: "X-Webhook-Signature", value: signature)
+            }
+
+            let response = try await client.post(URI(string: webhookURL), headers: headers) { req in
+                req.body = ByteBuffer(data: jsonData)
+            }
+
+            if response.status.code >= 200 && response.status.code < 300 {
+                logger.info("Member registration webhook sent successfully for user \(user.id?.uuidString ?? "unknown")")
+            } else {
+                logger.warning("Member registration webhook returned non-success status: \(response.status)")
+            }
+        } catch {
+            logger.error("Failed to send member registration webhook: \(error)")
+        }
+    }
+
+    private func generateSignature(for data: Data) -> String? {
+        guard let webhookSecret, !webhookSecret.isEmpty else {
+            logger.debug("Webhook secret not configured, skipping signature")
+            return nil
+        }
+
+        let key = SymmetricKey(data: Data(webhookSecret.utf8))
+        let signature = HMAC<SHA256>.authenticationCode(for: data, using: key)
+        return "sha256=" + Data(signature).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+struct MemberRegisteredPayload: Codable {
+    let event: String
+    let timestamp: String
+    let data: MemberData
+
+    struct MemberData: Codable {
+        let id: String
+        let firstName: String
+        let lastName: String
+        let email: String
+        let membershipLevel: String?
+    }
+}

--- a/servers/Sources/MembersServer/Services/WebhookService.swift
+++ b/servers/Sources/MembersServer/Services/WebhookService.swift
@@ -44,6 +44,7 @@ struct WebhookService {
             }
 
             let response = try await client.post(URI(string: webhookURL), headers: headers) { req in
+                req.timeout = .seconds(10)
                 req.body = ByteBuffer(data: jsonData)
             }
 

--- a/servers/Sources/MembersServer/Services/WebhookService.swift
+++ b/servers/Sources/MembersServer/Services/WebhookService.swift
@@ -63,7 +63,7 @@ struct WebhookService {
         }
     }
 
-    private func generateSignature(for data: Data) -> String? {
+    func generateSignature(for data: Data) -> String? {
         guard let webhookSecret, !webhookSecret.isEmpty else {
             logger.debug("Webhook secret not configured, skipping signature")
             return nil

--- a/servers/Sources/MembersServer/Services/WebhookService.swift
+++ b/servers/Sources/MembersServer/Services/WebhookService.swift
@@ -21,11 +21,16 @@ struct WebhookService {
             return
         }
 
+        guard let userId = user.id?.uuidString else {
+            logger.warning("Cannot send member registration webhook: user ID is nil")
+            return
+        }
+
         let payload = MemberRegisteredPayload(
             event: "member.registered",
             timestamp: ISO8601DateFormatter().string(from: Date()),
             data: MemberRegisteredPayload.MemberData(
-                id: user.id?.uuidString ?? "",
+                id: userId,
                 firstName: user.firstName,
                 lastName: user.lastName,
                 email: user.email,
@@ -49,7 +54,7 @@ struct WebhookService {
             }
 
             if response.status.code >= 200 && response.status.code < 300 {
-                logger.info("Member registration webhook sent successfully for user \(user.id?.uuidString ?? "unknown")")
+                logger.info("Member registration webhook sent successfully for user \(userId)")
             } else {
                 logger.warning("Member registration webhook returned non-success status: \(response.status)")
             }

--- a/servers/Tests/MembersServerTest/Services/WebhookServiceTests.swift
+++ b/servers/Tests/MembersServerTest/Services/WebhookServiceTests.swift
@@ -1,0 +1,109 @@
+import Crypto
+import Foundation
+import Testing
+
+@testable import MembersServer
+
+@Suite("WebhookService Tests")
+struct WebhookServiceTests {
+    @Test("Test HMAC signature generation")
+    func testSignatureGeneration() async throws {
+        let payload = MemberRegisteredPayload(
+            event: "member.registered",
+            timestamp: "2024-01-01T00:00:00Z",
+            data: MemberRegisteredPayload.MemberData(
+                id: "test-uuid",
+                firstName: "John",
+                lastName: "Doe",
+                email: "john@example.com",
+                membershipLevel: "Basic"
+            )
+        )
+
+        let jsonData = try JSONEncoder().encode(payload)
+        let secret = "test-secret-key"
+
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let signature = HMAC<SHA256>.authenticationCode(for: jsonData, using: key)
+        let signatureHex = "sha256=" + Data(signature).map { String(format: "%02x", $0) }.joined()
+
+        #expect(signatureHex.hasPrefix("sha256="))
+        #expect(signatureHex.count == 71)  // "sha256=" (7) + 64 hex chars
+    }
+
+    @Test("Test payload encoding")
+    func testPayloadEncoding() async throws {
+        let payload = MemberRegisteredPayload(
+            event: "member.registered",
+            timestamp: "2024-01-01T00:00:00Z",
+            data: MemberRegisteredPayload.MemberData(
+                id: "123e4567-e89b-12d3-a456-426614174000",
+                firstName: "Jane",
+                lastName: "Smith",
+                email: "jane@example.com",
+                membershipLevel: nil
+            )
+        )
+
+        let jsonData = try JSONEncoder().encode(payload)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        #expect(jsonString.contains("member.registered"))
+        #expect(jsonString.contains("Jane"))
+        #expect(jsonString.contains("Smith"))
+        #expect(jsonString.contains("jane@example.com"))
+        #expect(jsonString.contains("123e4567-e89b-12d3-a456-426614174000"))
+    }
+
+    @Test("Test payload with membership level")
+    func testPayloadWithMembershipLevel() async throws {
+        let payload = MemberRegisteredPayload(
+            event: "member.registered",
+            timestamp: "2024-01-01T00:00:00Z",
+            data: MemberRegisteredPayload.MemberData(
+                id: "test-id",
+                firstName: "Test",
+                lastName: "User",
+                email: "test@example.com",
+                membershipLevel: "Premium"
+            )
+        )
+
+        let jsonData = try JSONEncoder().encode(payload)
+        let jsonString = String(data: jsonData, encoding: .utf8)!
+
+        #expect(jsonString.contains("Premium"))
+    }
+
+    @Test("Test signature verification")
+    func testSignatureVerification() async throws {
+        let payload = MemberRegisteredPayload(
+            event: "member.registered",
+            timestamp: "2024-01-01T00:00:00Z",
+            data: MemberRegisteredPayload.MemberData(
+                id: "verify-test",
+                firstName: "Verify",
+                lastName: "Test",
+                email: "verify@example.com",
+                membershipLevel: "Standard"
+            )
+        )
+
+        let jsonData = try JSONEncoder().encode(payload)
+        let secret = "webhook-secret-123"
+
+        let key = SymmetricKey(data: Data(secret.utf8))
+        let signature = HMAC<SHA256>.authenticationCode(for: jsonData, using: key)
+
+        // Verify the signature is valid
+        let isValid = HMAC<SHA256>.isValidAuthenticationCode(signature, authenticating: jsonData, using: key)
+        #expect(isValid)
+
+        // Verify modified data fails
+        var modifiedData = jsonData
+        modifiedData[0] = modifiedData[0] ^ 0xFF
+        let isValidModified = HMAC<SHA256>.isValidAuthenticationCode(
+            signature, authenticating: modifiedData, using: key)
+        #expect(!isValidModified)
+    }
+}


### PR DESCRIPTION
## Summary
- Add signed webhook notifications when new members register
- Webhook payload includes member id, name, email, and membership level
- Payloads are signed with HMAC-SHA256 for verification on the receiving end
- Configurable via `MEMBER_WEBHOOK_URL` and `MEMBER_WEBHOOK_SECRET` environment variables

This allows us to hook up our accounting software to the members' site to copy over payees (members).

## Test plan
- [x] Unit tests pass for signature generation and payload encoding
- [x] All existing tests pass (117 tests)
- [ ] Deploy and verify webhook is received by n8n endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Member-registered webhooks: when configured, creating a member triggers a webhook with HMAC-SHA256 signing.

* **Configuration**
  * Added optional webhook settings (URL and secret) to environment example.

* **Bug Fixes**
  * Fixed formatting issue in environment example (missing closing quote/newline).

* **Tests**
  * New tests covering webhook payload encoding and signature generation/verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->